### PR TITLE
Fix displaying PNGShot images found in subdirectories

### DIFF
--- a/include/gallery.hpp
+++ b/include/gallery.hpp
@@ -23,9 +23,6 @@ struct MediaFile {
 
 class Gallery {
 public:
-    Gallery();
-    ~Gallery();
-
     void scan();
     int getCount() const;
     int getScreenshotCount() const;

--- a/include/gallery.hpp
+++ b/include/gallery.hpp
@@ -43,6 +43,6 @@ private:
     void scanStorage(CapsAlbumStorage storage);
     void parseFilename(MediaFile& file) const;
     void resolveGameNames();
-    void scanPngDirectory(const char* dirPath);
+    void scanPngDirectory(std::string dirPath, int depth);
     static std::string jsonEscape(const std::string& s);
 };

--- a/source/gallery.cpp
+++ b/source/gallery.cpp
@@ -10,9 +10,6 @@
 #include <map>
 #include <set>
 
-Gallery::Gallery() {}
-Gallery::~Gallery() {}
-
 // Scan a directory for PNG files saved by homebrew
 void Gallery::scanPngDirectory(const char* dirPath) {
     DIR* d = opendir(dirPath);

--- a/source/gallery.cpp
+++ b/source/gallery.cpp
@@ -10,13 +10,24 @@
 #include <map>
 #include <set>
 
+// YYYY/MM/DD/file.png
+constexpr int MAX_DIR_DEPTH = 3;
+
 // Scan a directory for PNG files saved by homebrew
-void Gallery::scanPngDirectory(const char* dirPath) {
-    DIR* d = opendir(dirPath);
+void Gallery::scanPngDirectory(std::string dirPath, int depth) {
+    DIR* d = opendir(dirPath.c_str());
     if (!d) return;
 
+    // If desired, we could create separate loops for depth < MAX_DIR_DEPTH
+    // or ==, and only scan for photos in the latter.
+    // I don't care enough to do so.
     struct dirent* ent;
     while ((ent = readdir(d)) != nullptr) {
+        if (ent->d_type == DT_DIR && depth < MAX_DIR_DEPTH) {
+            auto child = dirPath + "/" + ent->d_name;
+            scanPngDirectory(child, depth + 1);
+        }
+
         if (ent->d_type != DT_REG) continue;
 
         std::string name = ent->d_name;
@@ -28,7 +39,7 @@ void Gallery::scanPngDirectory(const char* dirPath) {
 
         MediaFile f;
         f.filename  = name;
-        f.fullPath  = std::string(dirPath) + "/" + name;
+        f.fullPath  = dirPath + "/" + name;
         f.type      = MEDIA_SCREENSHOT;
         f.gameName  = "Misc";
         f.gameId    = "png";
@@ -80,7 +91,7 @@ void Gallery::scan() {
         "sdmc:/emuMMC/SD01/Nintendo/Album/PNGs",
     };
     for (const char* dir : PNG_DIRS) {
-        scanPngDirectory(dir);
+        scanPngDirectory(dir, 0);
     }
 
     // Resolve game names via NS service


### PR DESCRIPTION
Recurse into subdirectories up to 3 levels deep and show images from all subdirectories.

If desired, we could change the code to only show PNG images exactly 3 folders deep. I did not implement this change and it's not necessary to make.

Fixes #2.